### PR TITLE
Fix build issues with 4.12

### DIFF
--- a/Source/DialogueSystem/DialogueSystem.Build.cs
+++ b/Source/DialogueSystem/DialogueSystem.Build.cs
@@ -19,7 +19,8 @@ public class DialogueSystem : ModuleRules
                 "UMG",
                 "SlateCore",
                 "Slate",
-                "AIModule"
+                "AIModule",
+                "GameplayTasks"
 			}
 		);
 	}


### PR DESCRIPTION
Simply added "GameplayTasks" to the public dependencies of DialogueSystem.Build.cs which solves build errors when building with 4.12.
