### PR TITLE
Update camera options

### DIFF
--- a/DialogueSystem.uplugin
+++ b/DialogueSystem.uplugin
@@ -11,15 +11,15 @@
 	"MarketplaceURL": "",
 	"SupportURL": "",
 	"Modules": [
-    {
-      "Name": "DialogueSystem",
-      "Type": "Runtime",
-      "LoadingPhase": "PreDefault"
-    },
-    {
-      "Name" : "DialogueSystemEditor",
-      "Type" : "Editor"
-	}
+		{
+		  "Name": "DialogueSystem",
+		  "Type": "Runtime",
+		  "LoadingPhase": "PreDefault"
+		},
+		{
+		  "Name" : "DialogueSystemEditor",
+		  "Type" : "Editor"
+		}
 	],
 	"EnabledByDefault": false,
 	"CanContainContent": false,

--- a/Source/DialogueSystem/Classes/BTDialogueTypes.h
+++ b/Source/DialogueSystem/Classes/BTDialogueTypes.h
@@ -186,14 +186,24 @@ USTRUCT(BlueprintType)
 struct DIALOGUESYSTEM_API FBTDialogueCinematicOptions
 {
 	GENERATED_USTRUCT_BODY()
+		/** Enable to play Matinee */
+		UPROPERTY(EditInstanceOnly, Category = Cinematic)
+		bool bPlayMatinee;
 
+	/** Matinee*/
+	UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category = Cinematic)
+		FString Matinee;
 	/** Enable to play Sequence */
 	UPROPERTY(EditInstanceOnly, Category = Cinematic)
 	bool bPlaySequence;
 
-	/** Loop Sequence */
+	/** Loop Matinee */
 	UPROPERTY(EditInstanceOnly, Category = Cinematic)
 	bool bLoop;
+
+	/** Autoplay Sequence */
+	UPROPERTY(EditInstanceOnly, Category = Cinematic)
+	bool bAutoPlay;
 
 	/** Sequence*/
 	UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category = Cinematic)

--- a/Source/DialogueSystem/Classes/BTDialogueTypes.h
+++ b/Source/DialogueSystem/Classes/BTDialogueTypes.h
@@ -4,6 +4,7 @@
 #include "Runtime/AIModule/Classes/BehaviorTree/BehaviorTreeTypes.h"
 #include "BehaviorTree/BlackboardComponent.h"
 #include "Engine/Texture2D.h"
+#include "Sound/SoundCue.h"
 #include "BTDialogueTypes.generated.h"
 
 /**
@@ -125,7 +126,7 @@ struct DIALOGUESYSTEM_API FBTDialogueSoundOptions
 
 	/** CUE to play */
 	UPROPERTY(EditInstanceOnly, Category = Sound)
-	USoundCue* SoundToPlay;
+		USoundCue* SoundToPlay;
 };
 
 USTRUCT()
@@ -177,15 +178,41 @@ struct DIALOGUESYSTEM_API FBTDialogueCameraOptions
 	UPROPERTY(EditInstanceOnly, Category = Camera)
 	FBlackboardKeySelector CameraToView;
 
+	/**Dialogue Rig reference*/
+	UPROPERTY(EditInstanceOnly, Category = Camera)
+		FBlackboardKeySelector BehindPersonACamera;
+	UPROPERTY(EditInstanceOnly, Category = Camera)
+		FBlackboardKeySelector CloseupPersonACamera;
+	UPROPERTY(EditInstanceOnly, Category = Camera)
+		FBlackboardKeySelector BehindPersonBCamera;
+	UPROPERTY(EditInstanceOnly, Category = Camera)
+		FBlackboardKeySelector CloseupPersonBCamera;
+	UPROPERTY(EditInstanceOnly, Category = Camera)
+		FBlackboardKeySelector WideAngleCamera;
+		
 	/** Player camera*/
 	UPROPERTY(EditInstanceOnly, Category = Camera)
 	FBlackboardKeySelector PlayerCamera;
+};
+
+
+UENUM(BlueprintType)
+enum class EDialogueCameraType :uint8
+{
+	None = 0,
+	BehindPersonA = 1 UMETA(DisplayName = "BehindA"),
+	CloseupPersonA = 2 UMETA(DisplayName = "CloseupA"),
+	BehindPersonB = 3 UMETA(DisplayName = "BehindB"),
+	CloseupPersonB = 4 UMETA(DisplayName = "CloseupB"),
+	WideAngle = 5 UMETA(DisplayName = "WideAngle"),
+
 };
 
 USTRUCT(BlueprintType)
 struct DIALOGUESYSTEM_API FBTDialogueCinematicOptions
 {
 	GENERATED_USTRUCT_BODY()
+
 		/** Enable to play Matinee */
 		UPROPERTY(EditInstanceOnly, Category = Cinematic)
 		bool bPlayMatinee;
@@ -195,7 +222,7 @@ struct DIALOGUESYSTEM_API FBTDialogueCinematicOptions
 		FString Matinee;
 	/** Enable to play Sequence */
 	UPROPERTY(EditInstanceOnly, Category = Cinematic)
-	bool bPlaySequence;
+	bool bPlaySeq;
 
 	/** Loop Matinee */
 	UPROPERTY(EditInstanceOnly, Category = Cinematic)
@@ -204,6 +231,12 @@ struct DIALOGUESYSTEM_API FBTDialogueCinematicOptions
 	/** Autoplay Sequence */
 	UPROPERTY(EditInstanceOnly, Category = Cinematic)
 	bool bAutoPlay;
+
+	UPROPERTY(EditInstanceOnly, Category = Cinematic)
+		bool bUseCam;
+
+	UPROPERTY(EditInstanceOnly, BlueprintReadwrite, Category = Cinematic)
+		EDialogueCameraType bDialogueCamType;
 
 	/** Sequence*/
 	UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category = Cinematic)

--- a/Source/DialogueSystem/Classes/BTDialogueTypes.h
+++ b/Source/DialogueSystem/Classes/BTDialogueTypes.h
@@ -187,17 +187,17 @@ struct DIALOGUESYSTEM_API FBTDialogueCinematicOptions
 {
 	GENERATED_USTRUCT_BODY()
 
-	/** Enable to play Matinee */
+	/** Enable to play Sequence */
 	UPROPERTY(EditInstanceOnly, Category = Cinematic)
-	bool bPlayMatinee;
+	bool bPlaySequence;
 
-	/** Loop Matinee */
+	/** Loop Sequence */
 	UPROPERTY(EditInstanceOnly, Category = Cinematic)
 	bool bLoop;
 
-	/** Matinee*/
+	/** Sequence*/
 	UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category = Cinematic)
-	FString Matinee;
+	FString Sequence;
 
 };
 

--- a/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
+++ b/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
@@ -2,12 +2,15 @@
 
 #pragma once
 #include "BehaviorTree/BTTaskNode.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 #include "BehaviorTree/BehaviorTreeComponent.h"
+#include "BTDialogueTypes.h"
 #include "BTContextNode_Interface.h"
 #include "Widget.h"
 #include "WidgetComponent.h"
 #include "UserWidget.h"
 #include "Camera/CameraComponent.h"
+#include "Runtime/CinematicCamera/Public/CineCameraComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
 #include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
 #include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
@@ -23,9 +26,15 @@ class DIALOGUESYSTEM_API UBTTask_ShowPhrases : public UBTTaskNode, public IBTCon
 {
 	GENERATED_UCLASS_BODY()
 
+
+	//UCineCameraComponent* GetActiveDialogueCamera();
 	virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
+
+
+	UCineCameraComponent* activeDialogueCam;
+
 	virtual FString GetStaticDescription() const override;
-	
+	void SetActiveDialogueCamera(UCineCameraComponent* cineCam);
 	void ShowNewDialoguePhrase(bool bSkip);
 	void ShowNewChar();
 	UWidget* GetEventListener(UWidgetTree* WidgetTree);
@@ -74,6 +83,9 @@ class DIALOGUESYSTEM_API UBTTask_ShowPhrases : public UBTTaskNode, public IBTCon
 	UPROPERTY(EditInstanceOnly, Category = Description)
 	uint32 bShowPropertyDetails : 1;
 
+
+	UFUNCTION(BlueprintCallable, Category = "DialogueSystem|Dialogue")
+		UCineCameraComponent* GetActiveDialogueCamera();
 	int32 ShowingNumPhrase;
 	int32 PhrasesCount;
 	bool bTextFinished;

--- a/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
+++ b/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
@@ -9,9 +9,9 @@
 #include "UserWidget.h"
 #include "Camera/CameraComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
+#include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
 #include "BTTask_ShowPhrases.generated.h"
 
-#include "Runtime/Engine/Classes/LevelSequence/LevelSequenceActor.h"
 
 
 /**

--- a/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
+++ b/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
@@ -11,6 +11,8 @@
 #include "BehaviorTree/BlackboardComponent.h"
 #include "BTTask_ShowPhrases.generated.h"
 
+#include "Runtime/Engine/Classes/LevelSequence/LevelSequenceActor.h"
+
 
 /**
 * Show dialogue task node.
@@ -87,7 +89,7 @@ class DIALOGUESYSTEM_API UBTTask_ShowPhrases : public UBTTaskNode, public IBTCon
 	UWidget* DialogueNameSlot;
 	UAudioComponent* GeneralAudioComponent;
 	UAudioComponent* PhraseAudioComponent;
-	AMatineeActor* MatineeActor;
+	ALevelSequenceActor* LevelSequenceActor;
 
 	int32 CurrentCharNum;
 	TArray<TCHAR> FullString;

--- a/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
+++ b/Source/DialogueSystem/Classes/BTTask_ShowPhrases.h
@@ -9,6 +9,7 @@
 #include "UserWidget.h"
 #include "Camera/CameraComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
+#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
 #include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
 #include "BTTask_ShowPhrases.generated.h"
 
@@ -89,6 +90,7 @@ class DIALOGUESYSTEM_API UBTTask_ShowPhrases : public UBTTaskNode, public IBTCon
 	UWidget* DialogueNameSlot;
 	UAudioComponent* GeneralAudioComponent;
 	UAudioComponent* PhraseAudioComponent;
+	AMatineeActor* MatineeActor;
 	ALevelSequenceActor* LevelSequenceActor;
 
 	int32 CurrentCharNum;

--- a/Source/DialogueSystem/Classes/BTTask_WaitAnswer.h
+++ b/Source/DialogueSystem/Classes/BTTask_WaitAnswer.h
@@ -76,7 +76,7 @@ private:
 	float TimerCount;
 	bool bIsUserWidget;
 	UUserWidget* Widget;
-	AMatineeActor* MatineeActor;
+	ALevelSequenceActor* LevelSequenceActor;
 
 public:
 	APlayerController* PlayerController;

--- a/Source/DialogueSystem/Classes/BTTask_WaitAnswer.h
+++ b/Source/DialogueSystem/Classes/BTTask_WaitAnswer.h
@@ -76,6 +76,7 @@ private:
 	float TimerCount;
 	bool bIsUserWidget;
 	UUserWidget* Widget;
+	AMatineeActor* MatineeActor;
 	ALevelSequenceActor* LevelSequenceActor;
 
 public:

--- a/Source/DialogueSystem/DialogueSystem.Build.cs
+++ b/Source/DialogueSystem/DialogueSystem.Build.cs
@@ -5,8 +5,7 @@ public class DialogueSystem : ModuleRules
 {
 	public DialogueSystem(ReadOnlyTargetRules Target) : base (Target)
 	{
-       // PCHUsage = ModuleRules.PCHUsageMode.NoSharedPCHs;
-       //PrivatePCHHeaderFile = "Private/DialogueSystemPrivatePCH.h";
+        PrivatePCHHeaderFile = "Private/DialogueSystemPrivatePCH.h";
 
         PrivateIncludePaths.AddRange(
 			new string[] {"DialogueSystem/Private"});

--- a/Source/DialogueSystem/DialogueSystem.Build.cs
+++ b/Source/DialogueSystem/DialogueSystem.Build.cs
@@ -1,5 +1,4 @@
 //Copyright (c) 2016 Artem A. Mavrin and other contributors
-
 using UnrealBuildTool;
 
 public class DialogueSystem : ModuleRules
@@ -7,7 +6,9 @@ public class DialogueSystem : ModuleRules
 	public DialogueSystem(ReadOnlyTargetRules Target) : base (Target)
 	{
 
-		PrivateIncludePaths.AddRange(
+       // PCHUsage = ModuleRules.PCHUsageMode.NoSharedPCHs;
+       //PrivatePCHHeaderFile = "Private/DialogueSystemPrivatePCH.h";
+        PrivateIncludePaths.AddRange(
 			new string[] {"DialogueSystem/Private"});
 
         PublicDependencyModuleNames.AddRange(
@@ -20,6 +21,7 @@ public class DialogueSystem : ModuleRules
                 "SlateCore",
                 "Slate",
                 "LevelSequence",
+                "CinematicCamera",
                 "MovieScene",
 								"AIModule",
                 "GameplayTasks"

--- a/Source/DialogueSystem/DialogueSystem.Build.cs
+++ b/Source/DialogueSystem/DialogueSystem.Build.cs
@@ -20,6 +20,7 @@ public class DialogueSystem : ModuleRules
                 "SlateCore",
                 "Slate",
                 "LevelSequence",
+                "MovieScene",
 								"AIModule",
                 "GameplayTasks"
 			}

--- a/Source/DialogueSystem/DialogueSystem.Build.cs
+++ b/Source/DialogueSystem/DialogueSystem.Build.cs
@@ -19,6 +19,7 @@ public class DialogueSystem : ModuleRules
                 "UMG",
                 "SlateCore",
                 "Slate",
+                "LevelSequence",
 								"AIModule",
                 "GameplayTasks"
 			}

--- a/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
+++ b/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
@@ -269,18 +269,19 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 			{
 				FName MeshKeyName = DialogueCharacterAnimationOptions.Mesh.SelectedKeyName;
 				BlackboardComp = OwnerComp.GetBlackboardComponent();
-				Mesh = Cast<USkeletalMeshComponent>(BlackboardComp->GetValueAsObject(MeshKeyName));
+					Mesh = Cast<USkeletalMeshComponent>(BlackboardComp->GetValueAsObject(MeshKeyName));
 				if (Mesh)
 				{
 					UAnimInstance *AnimInst = Mesh->GetAnimInstance();
-					if (AnimInst)
+					Mesh->PlayAnimation(DialogueCharacterAnimationOptions.Animation,DialogueCharacterAnimationOptions.bLoop);
+					/*if (AnimInst)
 					{
 						AnimInst->PlaySlotAnimationAsDynamicMontage(DialogueCharacterAnimationOptions.Animation, 
 							DialogueCharacterAnimationOptions.AnimationBlendOptions.SlotNodeName,
 							DialogueCharacterAnimationOptions.AnimationBlendOptions.BlendInTime,
 							DialogueCharacterAnimationOptions.AnimationBlendOptions.BlendOutTime,
 							DialogueCharacterAnimationOptions.AnimationBlendOptions.InPlayRate);
-					}
+					}*/
 					if (DialogueCharacterAnimationOptions.bWaitEndOfAnimation)
 					{
 						UAnimSequenceBase* SequenceBase = DialogueCharacterAnimationOptions.Animation;
@@ -427,6 +428,7 @@ void UBTTask_ShowPhrases::ShowNewDialoguePhrase(bool bSkip)
 		// cinematic
 		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
 		{
+			LevelSequenceActor->SequencePlayer->Stop();
 			//LevelSequenceActor->Stop();
 		}
 	}
@@ -463,7 +465,7 @@ void UBTTask_ShowPhrases::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Nod
 		CharacterAnimationDuration -= DeltaSeconds;
 		if (CharacterAnimationDuration <=0.0f && DialogueCharacterAnimationOptions.bLoop && !bTextFinished)
 		{
-			UAnimInstance *AnimInst = Mesh->GetAnimInstance();
+			/*
 			if (AnimInst)
 			{
 				AnimInst->PlaySlotAnimationAsDynamicMontage(DialogueCharacterAnimationOptions.Animation,
@@ -472,6 +474,7 @@ void UBTTask_ShowPhrases::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Nod
 					DialogueCharacterAnimationOptions.AnimationBlendOptions.BlendOutTime,
 					DialogueCharacterAnimationOptions.AnimationBlendOptions.InPlayRate);
 			}
+			*/
 			UAnimSequenceBase* SequenceBase = DialogueCharacterAnimationOptions.Animation;
 			CharacterAnimationDuration = SequenceBase->SequenceLength / SequenceBase->RateScale;
 		}

--- a/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
+++ b/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
@@ -211,7 +211,36 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 			// camera
 			if (DialogueCameraOptions.bUseCamera)
 			{
-				if (!DialogueCameraOptions.CameraToView.IsNone() && !DialogueCameraOptions.PlayerCamera.IsNone() && !DialogueCinematicOptions.bPlaySequence)
+				BlackboardComp = OwnerComp.GetBlackboardComponent();
+				UCineCameraComponent* CameraToView = Cast<UCineCameraComponent>(BlackboardComp->GetValueAsObject(DialogueCameraOptions.WideAngleCamera.SelectedKeyName));
+
+				if (DialogueCinematicOptions.bDialogueCamType != EDialogueCameraType::None)
+				{
+					switch (DialogueCinematicOptions.bDialogueCamType)
+					{
+					case EDialogueCameraType::WideAngle:
+						 CameraToView = Cast<UCineCameraComponent>(BlackboardComp->GetValueAsObject(DialogueCameraOptions.WideAngleCamera.SelectedKeyName));
+						break;
+					case EDialogueCameraType::BehindPersonA:
+						CameraToView = Cast<UCineCameraComponent>(BlackboardComp->GetValueAsObject(DialogueCameraOptions.BehindPersonACamera.SelectedKeyName));
+						break;
+					case EDialogueCameraType::CloseupPersonA:
+						CameraToView = Cast<UCineCameraComponent>(BlackboardComp->GetValueAsObject(DialogueCameraOptions.CloseupPersonACamera.SelectedKeyName));
+						break;
+					case EDialogueCameraType::BehindPersonB:
+						CameraToView = Cast<UCineCameraComponent>(BlackboardComp->GetValueAsObject(DialogueCameraOptions.BehindPersonBCamera.SelectedKeyName));
+						break;
+					case EDialogueCameraType::CloseupPersonB:
+						CameraToView = Cast<UCineCameraComponent>(BlackboardComp->GetValueAsObject(DialogueCameraOptions.CloseupPersonBCamera.SelectedKeyName));
+						break;
+					default:
+						CameraToView = Cast<UCineCameraComponent>(BlackboardComp->GetValueAsObject(DialogueCameraOptions.WideAngleCamera.SelectedKeyName));
+						break;
+					}
+				}
+				SetActiveDialogueCamera(CameraToView);
+				/*
+				if (!DialogueCameraOptions.CameraToView.IsNone() && !DialogueCameraOptions.PlayerCamera.IsNone() && !DialogueCinematicOptions.bPlaySeq)
 				{
 					FName CameraToViewKeyName = DialogueCameraOptions.CameraToView.SelectedKeyName;
 					BlackboardComp = OwnerComp.GetBlackboardComponent();
@@ -233,6 +262,7 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 						}
 					}
 				}
+				*/
 				
 			}
 			// cinematic
@@ -249,14 +279,14 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 					}
 				}
 			}
-			if (DialogueCinematicOptions.bPlaySequence && !DialogueCinematicOptions.Sequence.Equals("None"))
+			if (DialogueCinematicOptions.bPlaySeq && !DialogueCinematicOptions.Sequence.Equals("None"))
 			{
 				for (TActorIterator<ALevelSequenceActor> It(OwnerActor->GetWorld()); It; ++It)
 				{
 					LevelSequenceActor = *It;
 					if (LevelSequenceActor && LevelSequenceActor->GetName().Equals(DialogueCinematicOptions.Sequence))
 					{
-						LevelSequenceActor->bAutoPlay = DialogueCinematicOptions.bAutoPlay;
+					//	LevelSequenceActor->bAutoPlay = DialogueCinematicOptions.bAutoPlay;
 					//	LevelSequenceActor->PostInitializeComponents();
 						LevelSequenceActor->InitializePlayer();
 						break;
@@ -426,12 +456,24 @@ void UBTTask_ShowPhrases::ShowNewDialoguePhrase(bool bSkip)
 		}
 
 		// cinematic
-		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
+		if (DialogueCinematicOptions.bPlaySeq && LevelSequenceActor)
 		{
 			LevelSequenceActor->SequencePlayer->Stop();
 			//LevelSequenceActor->Stop();
 		}
 	}
+}
+void UBTTask_ShowPhrases::SetActiveDialogueCamera(UCineCameraComponent* cineCam)
+{
+	activeDialogueCam = cineCam;
+}
+
+
+UCineCameraComponent* UBTTask_ShowPhrases::GetActiveDialogueCamera()
+{
+	UCineCameraComponent* cineCam = nullptr;
+	cineCam = activeDialogueCam;
+	return cineCam;
 }
 
 void UBTTask_ShowPhrases::ShowNewChar()

--- a/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
+++ b/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
@@ -5,7 +5,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Sound/SoundCue.h"
 /*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"*/
-#include "Runtime/Engine/Classes/LevelSequence/LevelSequenceActor.h"
+#include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
 #include "UserWidget.h"
 #include "WidgetComponent.h"
 #include "BTDialogueTypes.h"
@@ -243,8 +243,8 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 					LevelSequenceActor = *It;
 					if (LevelSequenceActor && LevelSequenceActor->GetName().Equals(DialogueCinematicOptions.Sequence))
 					{
-						LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
-						LevelSequenceActor->Play();
+					//	LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
+						LevelSequenceActor->PostInitializeComponents();
 						break;
 					}
 				}
@@ -413,7 +413,7 @@ void UBTTask_ShowPhrases::ShowNewDialoguePhrase(bool bSkip)
 		// cinematic
 		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
 		{
-			LevelSequenceActor->Stop();
+			//LevelSequenceActor->Stop();
 		}
 	}
 }

--- a/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
+++ b/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
@@ -4,7 +4,8 @@
 #include "SoundDefinitions.h"
 #include "Kismet/GameplayStatics.h"
 #include "Sound/SoundCue.h"
-#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
+/*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"*/
+#include "Runtime/Engine/Classes/LevelSequence/LevelSequenceActor.h"
 #include "UserWidget.h"
 #include "WidgetComponent.h"
 #include "BTDialogueTypes.h"
@@ -210,7 +211,7 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 			// camera
 			if (DialogueCameraOptions.bUseCamera)
 			{
-				if (!DialogueCameraOptions.CameraToView.IsNone() && !DialogueCameraOptions.PlayerCamera.IsNone() && !DialogueCinematicOptions.bPlayMatinee)
+				if (!DialogueCameraOptions.CameraToView.IsNone() && !DialogueCameraOptions.PlayerCamera.IsNone() && !DialogueCinematicOptions.bPlaySequence)
 				{
 					FName CameraToViewKeyName = DialogueCameraOptions.CameraToView.SelectedKeyName;
 					BlackboardComp = OwnerComp.GetBlackboardComponent();
@@ -235,15 +236,15 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 				
 			}
 			// cinematic
-			if (DialogueCinematicOptions.bPlayMatinee && !DialogueCinematicOptions.Matinee.Equals("None"))
+			if (DialogueCinematicOptions.bPlaySequence && !DialogueCinematicOptions.Sequence.Equals("None"))
 			{
-				for (TActorIterator<AMatineeActor> It(OwnerActor->GetWorld()); It; ++It)
+				for (TActorIterator<ALevelSequenceActor> It(OwnerActor->GetWorld()); It; ++It)
 				{
-					MatineeActor = *It;
-					if (MatineeActor && MatineeActor->GetName().Equals(DialogueCinematicOptions.Matinee))
+					LevelSequenceActor = *It;
+					if (LevelSequenceActor && LevelSequenceActor->GetName().Equals(DialogueCinematicOptions.Sequence))
 					{
-						MatineeActor->bLooping = DialogueCinematicOptions.bLoop;
-						MatineeActor->Play();
+						LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
+						LevelSequenceActor->Play();
 						break;
 					}
 				}
@@ -410,9 +411,9 @@ void UBTTask_ShowPhrases::ShowNewDialoguePhrase(bool bSkip)
 		}
 
 		// cinematic
-		if (DialogueCinematicOptions.bPlayMatinee && MatineeActor)
+		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
 		{
-			MatineeActor->Stop();
+			LevelSequenceActor->Stop();
 		}
 	}
 }

--- a/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
+++ b/Source/DialogueSystem/Private/BTTask_ShowPhrases.cpp
@@ -4,7 +4,7 @@
 #include "SoundDefinitions.h"
 #include "Kismet/GameplayStatics.h"
 #include "Sound/SoundCue.h"
-/*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"*/
+#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
 #include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
 #include "UserWidget.h"
 #include "WidgetComponent.h"
@@ -236,6 +236,19 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 				
 			}
 			// cinematic
+			if (DialogueCinematicOptions.bPlayMatinee && !DialogueCinematicOptions.Matinee.Equals("None"))
+			{
+				for (TActorIterator<AMatineeActor> It(OwnerActor->GetWorld()); It; ++It)
+				{
+					MatineeActor = *It;
+					if (MatineeActor && MatineeActor->GetName().Equals(DialogueCinematicOptions.Matinee))
+					{
+						MatineeActor->bLooping = DialogueCinematicOptions.bLoop;
+						MatineeActor->Play();
+						break;
+					}
+				}
+			}
 			if (DialogueCinematicOptions.bPlaySequence && !DialogueCinematicOptions.Sequence.Equals("None"))
 			{
 				for (TActorIterator<ALevelSequenceActor> It(OwnerActor->GetWorld()); It; ++It)
@@ -243,8 +256,9 @@ EBTNodeResult::Type UBTTask_ShowPhrases::ExecuteTask(UBehaviorTreeComponent& Own
 					LevelSequenceActor = *It;
 					if (LevelSequenceActor && LevelSequenceActor->GetName().Equals(DialogueCinematicOptions.Sequence))
 					{
-					//	LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
-						LevelSequenceActor->PostInitializeComponents();
+						LevelSequenceActor->bAutoPlay = DialogueCinematicOptions.bAutoPlay;
+					//	LevelSequenceActor->PostInitializeComponents();
+						LevelSequenceActor->InitializePlayer();
 						break;
 					}
 				}

--- a/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
+++ b/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
@@ -14,7 +14,7 @@
 #include "BTTask_ShowPhrases.h"
 #include "BTTask_CloseDialogue.h"
 /*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"*/
-#include "Runtime/Engine/Classes/LevelSequence/LevelSequenceActor.h"
+#include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
 #include "UObjectToken.h"
 
 #define LOCTEXT_NAMESPACE "DialogueSystem"
@@ -215,8 +215,8 @@ EBTNodeResult::Type UBTTask_WaitAnswer::ExecuteTask(UBehaviorTreeComponent& Owne
 				LevelSequenceActor = *It;
 				if (LevelSequenceActor && LevelSequenceActor->GetName().Equals(DialogueCinematicOptions.Sequence))
 				{
-					LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
-					LevelSequenceActor->Play();
+					//LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
+					LevelSequenceActor->PostInitializeComponents();
 					break;
 				}
 			}
@@ -260,7 +260,7 @@ void UBTTask_WaitAnswer::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Node
 		// cinematic
 		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
 		{
-			LevelSequenceActor->Stop();
+			//LevelSequenceActor->Stop();
 		}
 		// Event Listener
 		UWidget* DialogueEventListener = WidgetTree->FindWidget(FName("DialogueEventListener"));

--- a/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
+++ b/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
@@ -13,7 +13,7 @@
 #include "GameFramework/PlayerController.h"
 #include "BTTask_ShowPhrases.h"
 #include "BTTask_CloseDialogue.h"
-/*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"*/
+#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
 #include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
 #include "UObjectToken.h"
 
@@ -208,6 +208,20 @@ EBTNodeResult::Type UBTTask_WaitAnswer::ExecuteTask(UBehaviorTreeComponent& Owne
 		}
 
 		// cinematic
+		if (DialogueCinematicOptions.bPlayMatinee && !DialogueCinematicOptions.Matinee.Equals("None"))
+		{
+			for (TActorIterator<AMatineeActor> It(OwnerActor->GetWorld()); It; ++It)
+			{
+				MatineeActor = *It;
+				if (MatineeActor && MatineeActor->GetName().Equals(DialogueCinematicOptions.Matinee))
+				{
+					MatineeActor->bLooping = DialogueCinematicOptions.bLoop;
+					MatineeActor->Play();
+					break;
+				}
+			}
+		}
+
 		if (DialogueCinematicOptions.bPlaySequence && !DialogueCinematicOptions.Sequence.Equals("None"))
 		{
 			for (TActorIterator<ALevelSequenceActor> It(OwnerActor->GetWorld()); It; ++It)
@@ -258,6 +272,10 @@ void UBTTask_WaitAnswer::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Node
 	if (bAnswerDone)
 	{
 		// cinematic
+		if (DialogueCinematicOptions.bPlayMatinee && MatineeActor)
+		{
+			MatineeActor->Stop();
+		}
 		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
 		{
 			//LevelSequenceActor->Stop();

--- a/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
+++ b/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
@@ -222,7 +222,7 @@ EBTNodeResult::Type UBTTask_WaitAnswer::ExecuteTask(UBehaviorTreeComponent& Owne
 			}
 		}
 
-		if (DialogueCinematicOptions.bPlaySequence && !DialogueCinematicOptions.Sequence.Equals("None"))
+		if (DialogueCinematicOptions.bPlaySeq && !DialogueCinematicOptions.Sequence.Equals("None"))
 		{
 			for (TActorIterator<ALevelSequenceActor> It(OwnerActor->GetWorld()); It; ++It)
 			{
@@ -230,7 +230,7 @@ EBTNodeResult::Type UBTTask_WaitAnswer::ExecuteTask(UBehaviorTreeComponent& Owne
 				if (LevelSequenceActor && LevelSequenceActor->GetName().Equals(DialogueCinematicOptions.Sequence))
 				{
 					//LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
-					LevelSequenceActor->PostInitializeComponents();
+					//LevelSequenceActor->PostInitializeComponents();
 					break;
 				}
 			}
@@ -276,7 +276,7 @@ void UBTTask_WaitAnswer::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Node
 		{
 			MatineeActor->Stop();
 		}
-		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
+		if (DialogueCinematicOptions.bPlaySeq && LevelSequenceActor)
 		{
 			//LevelSequenceActor->Stop();
 		}

--- a/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
+++ b/Source/DialogueSystem/Private/BTTask_WaitAnswer.cpp
@@ -13,7 +13,8 @@
 #include "GameFramework/PlayerController.h"
 #include "BTTask_ShowPhrases.h"
 #include "BTTask_CloseDialogue.h"
-#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
+/*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"*/
+#include "Runtime/Engine/Classes/LevelSequence/LevelSequenceActor.h"
 #include "UObjectToken.h"
 
 #define LOCTEXT_NAMESPACE "DialogueSystem"
@@ -207,15 +208,15 @@ EBTNodeResult::Type UBTTask_WaitAnswer::ExecuteTask(UBehaviorTreeComponent& Owne
 		}
 
 		// cinematic
-		if (DialogueCinematicOptions.bPlayMatinee && !DialogueCinematicOptions.Matinee.Equals("None"))
+		if (DialogueCinematicOptions.bPlaySequence && !DialogueCinematicOptions.Sequence.Equals("None"))
 		{
-			for (TActorIterator<AMatineeActor> It(OwnerActor->GetWorld()); It; ++It)
+			for (TActorIterator<ALevelSequenceActor> It(OwnerActor->GetWorld()); It; ++It)
 			{
-				MatineeActor = *It;
-				if (MatineeActor && MatineeActor->GetName().Equals(DialogueCinematicOptions.Matinee))
+				LevelSequenceActor = *It;
+				if (LevelSequenceActor && LevelSequenceActor->GetName().Equals(DialogueCinematicOptions.Sequence))
 				{
-					MatineeActor->bLooping = DialogueCinematicOptions.bLoop;
-					MatineeActor->Play();
+					LevelSequenceActor->bLooping = DialogueCinematicOptions.bLoop;
+					LevelSequenceActor->Play();
 					break;
 				}
 			}
@@ -257,9 +258,9 @@ void UBTTask_WaitAnswer::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Node
 	if (bAnswerDone)
 	{
 		// cinematic
-		if (DialogueCinematicOptions.bPlayMatinee && MatineeActor)
+		if (DialogueCinematicOptions.bPlaySequence && LevelSequenceActor)
 		{
-			MatineeActor->Stop();
+			LevelSequenceActor->Stop();
 		}
 		// Event Listener
 		UWidget* DialogueEventListener = WidgetTree->FindWidget(FName("DialogueEventListener"));

--- a/Source/DialogueSystem/Private/QuestBook.cpp
+++ b/Source/DialogueSystem/Private/QuestBook.cpp
@@ -1,7 +1,7 @@
 //Copyright (c) 2016 Artem A. Mavrin and other contributors
 
 #pragma once
-#include "DialogueSystemPrivatePCH.h"
+//#include "DialogueSystemPrivatePCH.h"
 #include "QuestBook.h"
 
 FQuest UQuestBook::GetQuest(int32 ID)

--- a/Source/DialogueSystemEditor/DialoguePluginProjEditor.Build.cs
+++ b/Source/DialogueSystemEditor/DialoguePluginProjEditor.Build.cs
@@ -1,0 +1,43 @@
+//Copyright (c) 2016 Artem A. Mavrin and other contributors
+
+using UnrealBuildTool;
+
+public class PluginSystemEditor : ModuleRules
+{
+    public PluginSystemEditor(ReadOnlyTargetRules Target) : base (Target)
+	{
+
+		PrivateIncludePaths.AddRange(
+            new string[] { "" });
+
+        PublicDependencyModuleNames.AddRange(
+			new string[]
+			{
+				"Core",
+				"CoreUObject",
+				"Engine",
+                "UMG",
+                "SlateCore",
+                "Projects",
+                "Slate",
+                "UnrealEd",
+                "DetailCustomizations",
+                "PropertyEditor",
+                "EditorStyle",
+                "InputCore",
+			}
+		);
+
+        PrivateIncludePathModuleNames.AddRange(
+            new string[] {
+                "AssetTools"
+            }
+        );
+
+        DynamicallyLoadedModuleNames.AddRange(
+            new string[] {
+                "AssetTools"
+            }
+        );
+    }
+}

--- a/Source/DialogueSystemEditor/DialogueSystemEditor.Build.cs
+++ b/Source/DialogueSystemEditor/DialogueSystemEditor.Build.cs
@@ -25,6 +25,7 @@ public class DialogueSystemEditor : ModuleRules
                 "PropertyEditor",
                 "EditorStyle",
                 "InputCore",
+                "LevelSequence",
                 "DialogueSystem"
 			}
 		);

--- a/Source/DialogueSystemEditor/DialogueSystemEditor.Build.cs
+++ b/Source/DialogueSystemEditor/DialogueSystemEditor.Build.cs
@@ -6,8 +6,7 @@ public class DialogueSystemEditor : ModuleRules
 {
     public DialogueSystemEditor(ReadOnlyTargetRules Target) : base (Target)
 	{
-        //PCHUsage = ModuleRules.PCHUsageMode.NoSharedPCHs;
-       // PrivatePCHHeaderFile = "Private/DialogueSystemEditorPrivatePCH.h";
+        PrivatePCHHeaderFile = "Private/DialogueSystemEditorPrivatePCH.h";
 
         PrivateIncludePaths.AddRange(
             new string[] { "DialogueSystemEditor/Private" });

--- a/Source/DialogueSystemEditor/DialogueSystemEditor.Build.cs
+++ b/Source/DialogueSystemEditor/DialogueSystemEditor.Build.cs
@@ -6,8 +6,10 @@ public class DialogueSystemEditor : ModuleRules
 {
     public DialogueSystemEditor(ReadOnlyTargetRules Target) : base (Target)
 	{
+        //PCHUsage = ModuleRules.PCHUsageMode.NoSharedPCHs;
+       // PrivatePCHHeaderFile = "Private/DialogueSystemEditorPrivatePCH.h";
 
-		PrivateIncludePaths.AddRange(
+        PrivateIncludePaths.AddRange(
             new string[] { "DialogueSystemEditor/Private" });
 
         PublicDependencyModuleNames.AddRange(
@@ -26,6 +28,7 @@ public class DialogueSystemEditor : ModuleRules
                 "EditorStyle",
                 "InputCore",
                 "LevelSequence",
+                "CinematicCamera",
                 "DialogueSystem"
 			}
 		);

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/QuestionCustomization.cpp
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/QuestionCustomization.cpp
@@ -4,11 +4,6 @@
 #include "DialogueSystemEditorPrivatePCH.h"
 #include "QuestionCustomization.h"
 
-#include "DetailLayoutBuilder.h"
-#include "DetailWidgetRow.h"
-#include "IDetailPropertyRow.h"
-#include "DetailCategoryBuilder.h"
-
 #define LOCTEXT_NAMESPACE "DialogueSystem"
 
 TSharedRef<IDetailCustomization> FQuestionDetails::MakeInstance()

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/QuestionCustomization.h
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/QuestionCustomization.h
@@ -2,7 +2,10 @@
 #pragma once
 
 #include "IDetailCustomization.h"
-
+#include "DetailLayoutBuilder.h"
+#include "DetailWidgetRow.h"
+#include "IDetailPropertyRow.h"
+#include "DetailCategoryBuilder.h"
 class IDetailLayoutBuilder;
 class IPropertyHandle;
 class SWidget;

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.cpp
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.cpp
@@ -3,7 +3,7 @@
 #include "ShowPhrasesCustomization.h"
 /*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
 */
-#include "Runtime/Engine/Classes/Sequencer/LevelSequenceActor.h"
+#include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
 #include "IDetailChildrenBuilder.h"
 
 #define LOCTEXT_NAMESPACE "DialogueSystem"
@@ -38,7 +38,7 @@ void FTextPhrasesCustomization::CustomizeChildren(TSharedRef<class IPropertyHand
 	SoundToPlay = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextPhrase, SoundToPlay));
 	ShowingTime = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextPhrase, ShowingTime));
 
-	ChildBuilder.AddChildContent(LOCTEXT("Phrase", "Phrase"))
+	ChildBuilder.AddCustomRow(LOCTEXT("Phrase", "Phrase"))
 		.NameContent()
 		[
 			Phrase->CreatePropertyNameWidget()
@@ -49,8 +49,8 @@ void FTextPhrasesCustomization::CustomizeChildren(TSharedRef<class IPropertyHand
 			Phrase->CreatePropertyValueWidget()
 		];
 
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextPhrase, SoundToPlay)).ToSharedRef());
-	ChildBuilder.AddChildContent(LOCTEXT("ShowingTime", "ShowingTime"))
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextPhrase, SoundToPlay)).ToSharedRef());
+	ChildBuilder.AddCustomRow(LOCTEXT("ShowingTime", "ShowingTime"))
 		.NameContent()
 		[
 			ShowingTime->CreatePropertyNameWidget()
@@ -125,16 +125,16 @@ void FTextOptionsCustomization::CustomizeChildren(TSharedRef<class IPropertyHand
 	TextEffect = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, TextEffect));
 	Delay = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, Delay));
 
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, bShowTextPhrases)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, bHideLastPhrase)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, GeneralShowingTime)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, UseGeneralTime)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, bShowRandomPhrase)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, DialoguePhraseSlotName)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, DialogueQuestionsSlotName)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, Phrases)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, TextEffect)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, Delay)).ToSharedRef()).Visibility(TAttribute<EVisibility>(this, &FTextOptionsCustomization::GetDelayVisibility));
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, bShowTextPhrases)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, bHideLastPhrase)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, GeneralShowingTime)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, UseGeneralTime)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, bShowRandomPhrase)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, DialoguePhraseSlotName)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, DialogueQuestionsSlotName)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, Phrases)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, TextEffect)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueTextOptions, Delay)).ToSharedRef()).Visibility(TAttribute<EVisibility>(this, &FTextOptionsCustomization::GetDelayVisibility));
 }
 
 EVisibility FTextOptionsCustomization::GetDelayVisibility() const
@@ -180,10 +180,10 @@ void FCinematicOptionsCustomization::CustomizeChildren(TSharedRef<class IPropert
 	bLoop = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bLoop));
 	Sequence = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, Sequence));
 
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySequence)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bLoop)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySequence)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bLoop)).ToSharedRef());
 
-	ChildBuilder.AddChildContent(LOCTEXT("Sequence", "Sequence"))
+	ChildBuilder.AddCustomRow(LOCTEXT("Sequence", "Sequence"))
 		.NameContent()
 		[
 			Sequence->CreatePropertyNameWidget()
@@ -237,7 +237,7 @@ FText FCinematicOptionsCustomization::GetCurrentSequenceName() const
 	for (TObjectIterator<ALevelSequenceActor> It; It; ++It)
 	{
 		ALevelSequenceActor* LevelSequenceActor = *It;
-		if (SettingName.EqualTo(FText::FromString(ALevelSequenceActor->GetName())))
+		if (SettingName.EqualTo(FText::FromString(LevelSequenceActor->GetName())))
 		{
 			return SettingName;
 		}

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.cpp
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.cpp
@@ -207,12 +207,15 @@ void FCinematicOptionsCustomization::CustomizeChildren(TSharedRef<class IPropert
 		]
 		]
 		];
+	bUseCam = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bUseCam));
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bUseCam)).ToSharedRef());
 
-	bPlaySequence= StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySequence));
+
+	bPlaySeq= StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySeq));
 	bAutoPlay = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bAutoPlay));
 	Sequence = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, Sequence));
 
-	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySequence)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySeq)).ToSharedRef());
 	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bAutoPlay)).ToSharedRef());
 
 	ChildBuilder.AddCustomRow(LOCTEXT("Sequence", "Sequence"))
@@ -238,8 +241,29 @@ void FCinematicOptionsCustomization::CustomizeChildren(TSharedRef<class IPropert
 				]
 			]
 		];
+
+	bDialogueCamType = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bDialogueCamType));
+	//CamType = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, CamType));
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bDialogueCamType)).ToSharedRef());
+	//ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, CamType)).ToSharedRef()).Visibility(TAttribute<EVisibility>(this, &FCinematicOptionsCustomization::GetCamType));
+
 }
 
+/*
+EVisibility FCinematicOptionsCustomization::GetCamType() const
+{
+	uint8 Value;
+	bDialogueCamType->GetValue(Value);
+	if (Value == 1)
+	{
+		return EVisibility::Visible;
+	}
+	else
+	{
+		return EVisibility::Hidden;
+	}
+}
+*/
 void FCinematicOptionsCustomization::OnSettingSequenceChange(FString NewValue)
 {
 	Sequence->SetValueFromFormattedString(NewValue);

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.cpp
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.cpp
@@ -1,8 +1,9 @@
 
 #include "DialogueSystemEditorPrivatePCH.h"
 #include "ShowPhrasesCustomization.h"
-#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
-
+/*#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
+*/
+#include "Runtime/Engine/Classes/Sequencer/LevelSequenceActor.h"
 #include "IDetailChildrenBuilder.h"
 
 #define LOCTEXT_NAMESPACE "DialogueSystem"
@@ -175,17 +176,17 @@ void FCinematicOptionsCustomization::CustomizeHeader(TSharedRef<class IPropertyH
 
 void FCinematicOptionsCustomization::CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& ChildBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils)
 {
-	bPlayMatinee = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlayMatinee));
+	bPlaySequence= StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySequence));
 	bLoop = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bLoop));
-	Matinee = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, Matinee));
+	Sequence = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, Sequence));
 
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlayMatinee)).ToSharedRef());
+	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bPlaySequence)).ToSharedRef());
 	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FBTDialogueCinematicOptions, bLoop)).ToSharedRef());
 
-	ChildBuilder.AddChildContent(LOCTEXT("Matinee", "Matinee"))
+	ChildBuilder.AddChildContent(LOCTEXT("Sequence", "Sequence"))
 		.NameContent()
 		[
-			Matinee->CreatePropertyNameWidget()
+			Sequence->CreatePropertyNameWidget()
 		]
 	.ValueContent()
 		.HAlign(HAlign_Fill)
@@ -195,54 +196,54 @@ void FCinematicOptionsCustomization::CustomizeChildren(TSharedRef<class IPropert
 			.MaxWidth(109.0f)
 			[
 				SNew(SComboButton)
-				.OnGetMenuContent(this, &FCinematicOptionsCustomization::OnGetMatineeList)
+				.OnGetMenuContent(this, &FCinematicOptionsCustomization::OnGetSequenceList)
 				.ContentPadding(FMargin(2.0f, 2.0f))
 				.ButtonContent()
 				[
 					SNew(STextBlock)
-					.Text(this, &FCinematicOptionsCustomization::GetCurrentMatineeName)
+					.Text(this, &FCinematicOptionsCustomization::GetCurrentSequenceName)
 					.Font(IDetailLayoutBuilder::GetDetailFont())
 				]
 			]
 		];
 }
 
-void FCinematicOptionsCustomization::OnSettingMatineeChange(FString NewValue)
+void FCinematicOptionsCustomization::OnSettingSequenceChange(FString NewValue)
 {
-	Matinee->SetValueFromFormattedString(NewValue);
+	Sequence->SetValueFromFormattedString(NewValue);
 }
 
-TSharedRef<SWidget> FCinematicOptionsCustomization::OnGetMatineeList() const
+TSharedRef<SWidget> FCinematicOptionsCustomization::OnGetSequenceList() const
 {
 	FMenuBuilder MenuBuilder(true, NULL);
 
-	FUIAction ItemAction(FExecuteAction::CreateSP(this, &FCinematicOptionsCustomization::OnSettingMatineeChange, FString("None")));
+	FUIAction ItemAction(FExecuteAction::CreateSP(this, &FCinematicOptionsCustomization::OnSettingSequenceChange, FString("None")));
 	MenuBuilder.AddMenuEntry(FText::FromString(TEXT("None")), TAttribute<FText>(), FSlateIcon(), ItemAction);
 
-	for (TObjectIterator<AMatineeActor> It; It; ++It)
+	for (TObjectIterator<ALevelSequenceActor> It; It; ++It)
 	{
-		AMatineeActor* MatineeActor = *It;
-		FUIAction Action(FExecuteAction::CreateSP(this, &FCinematicOptionsCustomization::OnSettingMatineeChange, MatineeActor->GetName()));
-		MenuBuilder.AddMenuEntry(FText::FromString(MatineeActor->GetName()), TAttribute<FText>(), FSlateIcon(), Action);
+		ALevelSequenceActor* LevelSequenceActor = *It;
+		FUIAction Action(FExecuteAction::CreateSP(this, &FCinematicOptionsCustomization::OnSettingSequenceChange, LevelSequenceActor->GetName()));
+		MenuBuilder.AddMenuEntry(FText::FromString(LevelSequenceActor->GetName()), TAttribute<FText>(), FSlateIcon(), Action);
 	}
 
 	return MenuBuilder.MakeWidget();
 }
 
-FText FCinematicOptionsCustomization::GetCurrentMatineeName() const
+FText FCinematicOptionsCustomization::GetCurrentSequenceName() const
 {
 	FText SettingName;
-	Matinee->GetValueAsDisplayText(SettingName);
-	for (TObjectIterator<AMatineeActor> It; It; ++It)
+	Sequence->GetValueAsDisplayText(SettingName);
+	for (TObjectIterator<ALevelSequenceActor> It; It; ++It)
 	{
-		AMatineeActor* MatineeActor = *It;
-		if (SettingName.EqualTo(FText::FromString(MatineeActor->GetName())))
+		ALevelSequenceActor* LevelSequenceActor = *It;
+		if (SettingName.EqualTo(FText::FromString(ALevelSequenceActor->GetName())))
 		{
 			return SettingName;
 		}
 	}
 
-	Matinee->SetValueFromFormattedString(FString("None"));
+	Sequence->SetValueFromFormattedString(FString("None"));
 	return FText::FromString("None");
 }
 

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.h
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.h
@@ -57,12 +57,12 @@ public:
 	virtual void CustomizeHeader(TSharedRef<class IPropertyHandle> StructPropertyHandle, class FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
 	virtual void CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& ChildBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
 
-	void OnSettingMatineeChange(FString NewValue);
-	TSharedRef<SWidget> OnGetMatineeList() const;
-	FText GetCurrentMatineeName() const;
+	void OnSettingSequenceChange(FString NewValue);
+	TSharedRef<SWidget> OnGetSequenceList() const;
+	FText GetCurrentSequenceName() const;
 private:
 	/** Property handles of the properties we're editing */
-	TSharedPtr<IPropertyHandle> bPlayMatinee;
+	TSharedPtr<IPropertyHandle> bPlaySequence;
 	TSharedPtr<IPropertyHandle> bLoop;
-	TSharedPtr<IPropertyHandle> Matinee;
+	TSharedPtr<IPropertyHandle> Sequence;
 };

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.h
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.h
@@ -56,13 +56,20 @@ public:
 	/** IPropertyTypeCustomization interface */
 	virtual void CustomizeHeader(TSharedRef<class IPropertyHandle> StructPropertyHandle, class FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
 	virtual void CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& ChildBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
+	
+	void OnSettingMatineeChange(FString NewValue);
+	TSharedRef<SWidget> OnGetMatineeList() const;
+	FText GetCurrentMatineeName() const;
 
 	void OnSettingSequenceChange(FString NewValue);
 	TSharedRef<SWidget> OnGetSequenceList() const;
 	FText GetCurrentSequenceName() const;
 private:
+	TSharedPtr<IPropertyHandle> bPlayMatinee;
+	TSharedPtr<IPropertyHandle> Matinee;
 	/** Property handles of the properties we're editing */
 	TSharedPtr<IPropertyHandle> bPlaySequence;
 	TSharedPtr<IPropertyHandle> bLoop;
+	TSharedPtr<IPropertyHandle> bAutoPlay;
 	TSharedPtr<IPropertyHandle> Sequence;
 };

--- a/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.h
+++ b/Source/DialogueSystemEditor/Private/BehaviorTreeEditor/ShowPhrasesCustomization.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include "IPropertyTypeCustomization.h"
-
+#include "Runtime/Engine/Classes/Matinee/MatineeActor.h"
+#include "Runtime/LevelSequence/Public/LevelSequenceActor.h"
+#include "IDetailChildrenBuilder.h"
 class IPropertyHandle;
 
 
@@ -68,8 +70,10 @@ private:
 	TSharedPtr<IPropertyHandle> bPlayMatinee;
 	TSharedPtr<IPropertyHandle> Matinee;
 	/** Property handles of the properties we're editing */
-	TSharedPtr<IPropertyHandle> bPlaySequence;
+	TSharedPtr<IPropertyHandle> bPlaySeq;
 	TSharedPtr<IPropertyHandle> bLoop;
 	TSharedPtr<IPropertyHandle> bAutoPlay;
+	TSharedPtr<IPropertyHandle> bDialogueCamType;
+	TSharedPtr<IPropertyHandle> bUseCam;
 	TSharedPtr<IPropertyHandle> Sequence;
 };

--- a/Source/DialogueSystemEditor/Private/QuestBookEditor/QuestBookEditorCustomization.cpp
+++ b/Source/DialogueSystemEditor/Private/QuestBookEditor/QuestBookEditorCustomization.cpp
@@ -47,7 +47,7 @@ void FQuestBookEditorCustomization::CustomizeChildren(TSharedRef<class IProperty
 	Experience = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FQuest, Experience));
 	Tasks = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FQuest, Tasks));
 
-	ChildBuilder.AddChildContent(LOCTEXT("Title", "Title"))
+	ChildBuilder.AddCustomRow(LOCTEXT("Title", "Title"))
 		.NameContent()
 		[
 			Title->CreatePropertyNameWidget()
@@ -57,7 +57,7 @@ void FQuestBookEditorCustomization::CustomizeChildren(TSharedRef<class IProperty
 		[
 			Title->CreatePropertyValueWidget()
 		];
-	ChildBuilder.AddChildContent(LOCTEXT("Description", "Description"))
+	ChildBuilder.AddCustomRow(LOCTEXT("Description", "Description"))
 		.NameContent()
 		[
 			Description->CreatePropertyNameWidget()
@@ -67,7 +67,7 @@ void FQuestBookEditorCustomization::CustomizeChildren(TSharedRef<class IProperty
 		[
 			Description->CreatePropertyValueWidget()
 		];
-	ChildBuilder.AddChildContent(LOCTEXT("IntroText", "IntroText"))
+	ChildBuilder.AddCustomRow(LOCTEXT("IntroText", "IntroText"))
 		.NameContent()
 		[
 			IntroText->CreatePropertyNameWidget()
@@ -77,7 +77,7 @@ void FQuestBookEditorCustomization::CustomizeChildren(TSharedRef<class IProperty
 		[
 			IntroText->CreatePropertyValueWidget()
 		];
-	ChildBuilder.AddChildContent(LOCTEXT("ProgressText", "ProgressText"))
+	ChildBuilder.AddCustomRow(LOCTEXT("ProgressText", "ProgressText"))
 		.NameContent()
 		[
 			ProgressText->CreatePropertyNameWidget()
@@ -87,7 +87,7 @@ void FQuestBookEditorCustomization::CustomizeChildren(TSharedRef<class IProperty
 		[
 			ProgressText->CreatePropertyValueWidget()
 		];
-	ChildBuilder.AddChildContent(LOCTEXT("FinishText", "FinishText"))
+	ChildBuilder.AddCustomRow(LOCTEXT("FinishText", "FinishText"))
 		.NameContent()
 		[
 			FinishText->CreatePropertyNameWidget()
@@ -98,7 +98,7 @@ void FQuestBookEditorCustomization::CustomizeChildren(TSharedRef<class IProperty
 			FinishText->CreatePropertyValueWidget()
 		];
 
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FQuest, Experience)).ToSharedRef());
-	ChildBuilder.AddChildProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FQuest, Tasks)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FQuest, Experience)).ToSharedRef());
+	ChildBuilder.AddProperty(StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FQuest, Tasks)).ToSharedRef());
 
 }

--- a/Source/DialogueSystemEditor/Public/DialogueSystemEditorModule.h
+++ b/Source/DialogueSystemEditor/Public/DialogueSystemEditorModule.h
@@ -5,6 +5,13 @@
 #define DIALOGUESYSTEMEDITOR_MODULE_NAME "DialogueSystemEditor"
 
 #include "ModuleManager.h"
+#include "AssetToolsModule.h"
+
+#include "QuestBookAssetTypeActions.h"
+#include "DialogueSystemStyle.h"
+#include "QuestBookEditor/QuestBookEditorCustomization.h"
+#include "BehaviorTreeEditor/QuestionCustomization.h"
+#include "BehaviorTreeEditor/ShowPhrasesCustomization.h"
 
 //////////////////////////////////////////////////////////////////////////
 // IDialogueSystemModule


### PR DESCRIPTION
- Replace Matinee with LevelSequence
- Add cinematic options
- Animation information can be read directly from animation sequence
- Add new camera types 
  - BehindPersonA = 1
  - CloseupPersonA = 2
  - BehindPersonB = 3
  - CloseupPersonB = 4
  - WideAngle = 5

This is merge of changes done by @lightnarcissus 